### PR TITLE
Do not encode pathname as a single URI component.

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -212,6 +212,16 @@ test.describe('URL polyfill', function() {
       `);
     });
 
+    test.it('Test pathname variations', () => {
+      return tester.executeScript(driver, `
+        var url = new URL('test/long/path.html', 'http://www.example.com');
+        if(url.pathname !== '/test/long/path.html') throw new Error('Invalid pathname : ' + url.pathname);
+        url.pathname = 'a/b 1'
+        if(url.pathname !== '/a/b%201') throw new Error('Invalid pathname : ' + url.pathname);
+        return url;
+      `);
+    });
+
     test.it('Ensure url.href does\'nt finish with ? if url.search is empty', () => {
       return tester.executeScript(driver, `
         var url = new URL('https://www.example.com/');

--- a/tests/test.js
+++ b/tests/test.js
@@ -199,12 +199,12 @@ test.describe('URL polyfill', function() {
 
     test.it('Test URL with base', () => {
       return tester.executeScript(driver, `
-        var url = new URL('test', 'http://www.example.com');
+        var url = new URL('test', 'http://www.example.com/base');
         
         if(url.host !== 'www.example.com') throw new Error('Invalid host : ' + url.host);
         if(url.hostname !== 'www.example.com') throw new Error('Invalid hostname : ' + url.hostname);
         if(url.href !== 'http://www.example.com/test') throw new Error('Invalid href : ' + url.href);
-        if(url.pathname !== '/test') throw new Error('Invalid pathname : ' + url.pathname);
+        if(url.pathname !== '/base/test') throw new Error('Invalid pathname : ' + url.pathname);
         if(url.protocol !== 'http:') throw new Error('Invalid protocol : ' + url.protocol);
         if(url.search !== '') throw new Error('Invalid search : ' + url.search);
         

--- a/url.js
+++ b/url.js
@@ -29,6 +29,16 @@ else {
         };
     };
 }
+/**
+ * Encodes a path segment.
+ * RFC 3986 reserves !, ', (, ), and * as well, but we only escape space,
+ * like the implementations we are polyfilling.
+ */
+function encodePathSegment(segment) {
+  return segment.replace(/ /g, function (c) {
+    return '%' + c.charCodeAt(0).toString(16)
+  });
+}
 var URLSearchParams = /** @class */ (function () {
     function URLSearchParams(init) {
         var _this = this;
@@ -240,10 +250,16 @@ var URL = /** @class */ (function () {
             return this._parts.path ? this._parts.path : '/';
         },
         set: function (value) {
-            value = value.toString();
-            if ((value.length === 0) || (value.charAt(0) !== '/'))
-                value = '/' + value;
-            this._parts.path = encodeURIComponent(value);
+            value = value.toString().split('/');
+            for (var i = 0; i < value.length; i++) {
+              value[i] = encodePathSegment(value[i])
+            }
+            if (value[0]) {
+              // ensure joined string starts with slash.
+              value.unshift('')
+            }
+            value = value.join('/');
+            this._parts.path = value;
         },
         enumerable: true,
         configurable: true

--- a/url.js
+++ b/url.js
@@ -142,10 +142,17 @@ var URL = /** @class */ (function () {
                 password: baseParts.password,
                 hostname: baseParts.hostname,
                 port: baseParts.port,
-                path: urlParts.path || baseParts.path,
                 query: urlParts.query || baseParts.query,
                 hash: urlParts.hash,
             };
+        }
+        if (!urlParts.path) {
+          this.pathname = baseParts.path;
+        } else if (urlParts.path[0] !== '/') {
+          // relative path
+          this.pathname = baseParts.path + '/' + urlParts.path;
+        } else {
+          this.pathname = urlParts.path
         }
         // console.log(URL.parse(base), URL.parse(url), this._parts);
     }

--- a/url.ts
+++ b/url.ts
@@ -33,6 +33,17 @@ if(Symbol && Symbol.iterator && (typeof ([][Symbol.iterator]) === 'function')) {
   }
 }
 
+/**
+ * Encodes a path segment.
+ * RFC 3986 reserves !, ', (, ), and * and the implementation pipes the
+ * output of encodeURIComponent to a hex encoding pass for these special
+ * characters.
+ */
+function encodePathSegment(segment) {
+  return encodeURIComponent(segment).replace(/[!'()*]/g, function (c) {
+    return '%' + c.charCodeAt(0).toString(16)
+  });
+}
 
 
 export class URLSearchParams {
@@ -288,9 +299,12 @@ export class URL {
   }
 
   set pathname(value: string) {
-    value = value.toString();
-    if((value.length === 0) || (value.charAt(0) !== '/')) value = '/' + value;
-    this._parts.path = encodeURIComponent(value);
+    let chunks = value.toString().split('/').map(encodePathSegment);
+    if (chunks[0]) {
+      // ensure joined string starts with slash.
+      chunks.unshift('');
+    }
+    this._parts.path = chunks.join('/');
   }
 
 


### PR DESCRIPTION
Native URLs from supporting browsers allow you to include slashes in the URL. In particular, this piece was failing:

```js
let u = new URL('http://example.com/')
u.pathname = 'a/b'
```

Expected: `http://example.com/a/b`
Actual: `http://example.com/a%2Fb`

Please note that since I don't have webdriver, I didn't really run the tests. I'm not even sure that the implementation is the best one. But I forced it in the project I'm using and was able to manually verify it using the node REPL.