### PR TITLE
Use example.com and add a port

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Supported : 'hash', 'host', 'hostname', 'href', 'port', 'protocol', 'search', 't
 Example:
 
 ```js
-const url = new URL('https://www.yahoo.com/?fr=yset_ie_syc_oracle&type=orcl_hpset#page0');
+const url = new URL('https://www.example.com:8080/?fr=yset_ie_syc_oracle&type=orcl_hpset#page0');
 ```
 - hash: `"page0"`
-- host: `"www.yahoo.com"`
-- hostname: `"www.yahoo.com"`
-- href: `"https://www.yahoo.com/?fr=yset_ie_syc_oracle&type=orcl_hpset#page0"`
-- origin: `"https://www.yahoo.com"`
+- host: `"www.example.com:8080"`
+- hostname: `"www.example.com"`
+- href: `"https://www.example.com:8080/?fr=yset_ie_syc_oracle&type=orcl_hpset#page0"`
+- origin: `"https://www.example.com"`
 - pathname: `"/"`
 - port: `""`
 - protocol: `"https:"`
@@ -42,7 +42,7 @@ Supported : 'append', 'delete', 'get', 'getAll', 'has', 'set', 'forEach', 'keys'
 Example:
 
 ```js
-const url = new URL('https://www.yahoo.com/?fr=yset_ie_syc_oracle&type=orcl_hpset#page0');
+const url = new URL('https://www.example.com/?fr=yset_ie_syc_oracle&type=orcl_hpset#page0');
 url.searchParams.append('page', 0);
-console.log(url.toString()); // print: "https://www.yahoo.com/?fr=yset_ie_syc_oracle&type=orcl_hpset&page=0#page0"
+console.log(url.toString()); // print: "https://www.example.com/?fr=yset_ie_syc_oracle&type=orcl_hpset&page=0#page0"
 ```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ const url = new URL('https://www.example.com:8080/?fr=yset_ie_syc_oracle&type=or
 - host: `"www.example.com:8080"`
 - hostname: `"www.example.com"`
 - href: `"https://www.example.com:8080/?fr=yset_ie_syc_oracle&type=orcl_hpset#page0"`
-- origin: `"https://www.example.com"`
+- origin: `"https://www.example.com:8080"`
 - pathname: `"/"`
-- port: `""`
+- port: `"8080"`
 - protocol: `"https:"`
 - search: `"?fr=yset_ie_syc_oracle&type=orcl_hpset"`
 - searchParams: URLSearchParams (see next)


### PR DESCRIPTION
Just from the Readme, it wasn't clear to me what the difference between `host` and `hostname` was, I had to check back to the docs. Adding a port to the example URL make the difference clear.

I'm open to reverting the `yahoo` -> `example` change, but since it's just for example purposes I thought it would be more straightforward to use `example.com`.