### PR TITLE
fix: replace "+" to " " before decode

### DIFF
--- a/url-polyfill.js
+++ b/url-polyfill.js
@@ -42,7 +42,7 @@
   };
 
   var deserializeParam = function(value) {
-    return decodeURIComponent(value).replace(/\+/g, ' ');
+    return decodeURIComponent(String(value).replace(/\+/g, ' '));
   };
 
   var polyfillURLSearchParams = function() {


### PR DESCRIPTION
Fixes this

```js
> new URLSearchParams('a=2018-12-19T09:14:35%2B09:00').get('a')
"2018-12-19T09:14:35 09:00" // invalid!
```

Of course, the `+` is still decoded to white space

```js
> new URLSearchParams('a=one+two').get('a')
"one two"
```

I don't know the correct way to transpile `test.ts` and cannot understand how to run test.

Could anyone help me write test?